### PR TITLE
changes caused by org-format-latex

### DIFF
--- a/px.el
+++ b/px.el
@@ -65,7 +65,7 @@ POINT to replace.  If AT is nil replace statements everywhere."
                     px-temp-dir
                     'overlays
                     "Creating images...%s"
-                    at 'forbuffer
+                    'forbuffer
                     px-image-program))
 
 (defun px--set-temp-dir ()


### PR DESCRIPTION
As I've already said, compiling file ~/.emacs.d/elpa/px-20141006.548/px.el from elpa with emacs pachage manager finished with the following warning:

```
In px--create-preview:
px.el:65:4:Warning: org-format-latex called with 7 arguments, but accepts only
1-6
```

And px-preview stopped working.

I've tried downloading the package and adjusting the number of arguments.
As know almost nothing about lisp, I thought that "at" is odd and tried deleting it and recompiling on my own. That worked. The function px-toggle works for me again.
Now want to create my first pull request) Don't judge to severe)
What would you say?
**What steps are needed for changes to reach the elpa repo?**
